### PR TITLE
Move powerlevel10k.zsh-theme source line to .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -70,4 +70,6 @@ function dg_query() {
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
+[ -f ~/powerlevel10k/powerlevel10k.zsh-theme ] && . ~/powerlevel10k/powerlevel10k.zsh-theme
+
 export ANOMALO_DISABLE_MULTIPROCESSING=true

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,5 @@
 # Install p10k
 git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ~/powerlevel10k
-echo 'source ~/powerlevel10k/powerlevel10k.zsh-theme' >>~/.zshrc
 
 SCRIPT=$(readlink -f "$0")
 BASEDIR=$(dirname "$SCRIPT")


### PR DESCRIPTION
`install.sh` is writing this line to `~/.zshrc` before `~/.zshrc` is later (over)written by a symlink. Moving this line to `.zshrc` directly may improve bootstrapping on Codespaces.